### PR TITLE
Change setup to have one db per server

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -24,7 +24,7 @@ func listChannels(mux *httpMux) http.HandlerFunc {
 			w.Write([]byte("invalid server id"))
 			return
 		}
-		channels, err := mux.readDB.ListChannels(r.Context(), database.ListChannelsParams{
+		channels, err := mux.serverDBs[serverID].ListChannels(r.Context(), database.ListChannelsParams{
 			ServerID: validServerID,
 			Limit:    10,
 		})
@@ -74,7 +74,7 @@ func createChannels(mux *httpMux) http.HandlerFunc {
 		}
 		req.ChannelID = ulid.Make()
 		req.CreatedAt = time.Now().UnixMilli()
-		err = mux.writeDB.CreateChannel(r.Context(), req)
+		err = mux.serverDBs[serverID].CreateChannel(r.Context(), req)
 		if err != nil {
 			mux.log.Error("could not create channel", "error", err.Error())
 			w.WriteHeader(http.StatusInternalServerError)

--- a/config.go
+++ b/config.go
@@ -40,6 +40,8 @@ func loadConfigFromEnv() *config {
 			panic(err)
 		}
 		c.dataPath = path.Join(homeDir, ".fuwa")
+	} else {
+		c.dataPath = path.Join(c.dataPath, ".fuwa")
 	}
 	switch os.Getenv("FUWA_LOG_LEVEL") {
 	case "debug":

--- a/http.go
+++ b/http.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/oklog/ulid/v2"
-	"github.com/waifu-devs/fuwa-server/database"
 )
 
 // httpMux is a HTTP server
@@ -17,14 +15,9 @@ type httpMux struct {
 
 	log *slog.Logger
 
-	// otel stuff
-	// tracer trace.Tracer
+	cfg *config
 
-	writeDBConn *sql.DB
-	readDBConn  *sql.DB
-	readDB      *database.Queries
-	writeDB     *database.Queries
-	cfg         *config
+	serverDBs map[string]*server
 }
 
 type httpResponse struct {


### PR DESCRIPTION
Update the setup to have one database per server and store all databases under the `$FUWA_DATA/.fuwa` directory.

* **config.go**
  - Update `dataPath` to include `.fuwa` directory.
  - Update `loadConfigFromEnv` to set `dataPath` to `$FUWA_DATA/.fuwa`.

* **main.go**
  - Add `server` struct to hold read and write database connections.
  - Initialize `serverConnections` map to store server-specific database connections.
  - List all files in the `cfg.dataPath` directory and create connections to all databases.
  - Update `createConnectionString` to construct the database file path using `serverID`.
  - Update `createDatabaseConnection` to accept `serverID` parameter.
  - Update `applyMigrations` to apply migrations to each server-specific database file.

* **http.go**
  - Update `httpMux` struct to include a map of `serverID` to a struct that contains two `*database.Queries`, one for read and one for write operations.

* **channels.go**
  - Update `listChannels` to use the appropriate database connection based on `serverID`.
  - Update `createChannels` to use the appropriate database connection based on `serverID`.

* **servers.go**
  - Update `listServers` to use the appropriate database connection based on `serverID`.
  - Update `createServers` to create a new database file and apply migrations when creating a new server.
  - Add the new database connection to the `serverDBs` map.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/waifu-devs/fuwa-server?shareId=e645d456-d802-460b-84bb-202b49eafd04).