### PR TITLE
Change GitHub workflow to not deploy to Docker on PRs

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -13,8 +13,6 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Remove the `pull_request` trigger from the GitHub workflow file `.github/workflows/docker_publish.yml`.

* The workflow now only deploys to Docker on push events to the `main` branch and on semver tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/waifu-devs/fuwa-server?shareId=78213eb3-f0e3-44e4-b2e8-ba379942a5c8).